### PR TITLE
Add project structure to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,29 @@ The process for generating a QR code is clear. However, for retrieving files, no
 
 If additional steps are needed, or you face issues, feel free to raise a question or open an issue in the repository!
 
+## Project Structure
+
+```bash
+amanraox-share-bits-wirelessly/
+    ├── README.md
+    ├── LICENSE
+    ├── dl.html
+    ├── generate_qr.py
+    ├── index.html
+    ├── requirements.txt
+    ├── style.css
+    ├── asset/
+    └── .github/
+        └── workflows/
+            ├── auto-label.yml
+            ├── detect-duplicate.yml
+            ├── issue-close-open.yml
+            ├── pr-checker.yml
+            ├── pr-merge.yml
+            ├── pr-raise.yml Latest
+            └── static.yml
+```
+
 ## CONTRIBUTING 
 
 We welcome contributions to SHare Bits Wirelessly! To contribute:


### PR DESCRIPTION
#31 
Hi @amanraox, I am currently participating in the SWOC task.

This PR adds the project structure section to the README file to help contributors understand the repository layout.

1)  Added a detailed project structure section to the README.
2)  Organized the structure in a clear and readable format.

![image](https://github.com/user-attachments/assets/e164170e-0c0c-4191-90b7-53c9e82b4238)

