### PR TITLE
Added dialog box for file size warning

### DIFF
--- a/index.html
+++ b/index.html
@@ -175,9 +175,11 @@
 
         function onFileLoaded(filename, dataUrl) {
             if (dataUrl.length + filename.length > 2000) {
-                alert(`File ${filename} is too large for QR code!`);
-                return;
-            }
+                    const dialog = document.getElementById("fileSizeDialog");
+                    document.getElementById("dialogText").innerText = `File ${filename} is too large for the QR code!`;
+                    dialog.showModal(); // Opens the dialog
+                }
+
             const b64 = encodeURIComponent(dataUrl.split(',')[1]);
             const url = `${WEB_URL_PREFIX}?f=${filename}#${b64}`;
             document.getElementById('qrcode').innerHTML = '';
@@ -272,6 +274,12 @@
             window.scrollTo({ top: 0, behavior: 'smooth' });
         }
     </script>
+    <dialog id="fileSizeDialog">
+        <p id="dialogText"></p>
+        <button id="closeDialogBtn" onclick="document.getElementById('fileSizeDialog').close()">OK</button>
+    </dialog>
+    
+    
 </body>
 
 </html>

--- a/style.css
+++ b/style.css
@@ -489,3 +489,27 @@ footer a:hover {
     background-color: #0056b3;
     transform: scale(1.03);
 }
+dialog {
+    border: none;
+    border-radius: 10px;
+    padding: 20px;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+    text-align: center;
+}
+
+dialog::backdrop {
+    background: rgba(0, 0, 0, 0.3);
+}
+
+#closeDialogBtn {
+    background-color: #6366f1;
+    color: white;
+    border: none;
+    padding: 8px 16px;
+    border-radius: 5px;
+    cursor: pointer;
+}
+
+#closeDialogBtn:hover {
+    background-color:  #3c3fef;
+}


### PR DESCRIPTION
**Issue: #39** 

**Changed file size alert to a dialog box.**
Replaced `window.alert()` with a non-blocking `<dialog>` box for better user experience. Added an `id` to the button and used `showModal()` to display the message.

![image](https://github.com/user-attachments/assets/00e523ae-0ab1-4668-99ca-d456f73c4817)



Contributed under SWOC'25.
